### PR TITLE
Porting of Catppuccin Themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,17 @@
 2. Search for a new Note with the name `Custom CSS`
 3. Click on `Add Blank CSS Block`
 4. Paste the code from your desired Flavour into the block
-   1. [🌻 Latte](themes/latte.css)
-   2. [🪴 Frappé](themes/frappe.css)
-   3. [🌺 Macchiato](thenes/macchiato.css)
-   4. [🌿 Mocha](themes/mocha.css)
+    1. [🌻 Latte](latte/theme.css)
+    2. [🪴 Frappé](frapp%C3%A9/theme.css)
+    3. [🌺 Macchiato](macchiato/theme.css)
+    4. [🌿 Mocha](mocha/theme.css)
 
-
+> If custom CSS is preventing the loading of remnote, visit <http://www.remnote.com/notes?disableCustomCSS> ([From CSS Docs](https://plugins.remnote.com/custom-css))
 
 ## 💝 Thanks to
 
-- [justTOBBI](https://github.com/justTOBBI)
-- [colderinit](https://github.com/colderinit)
+-   [justTOBBI](https://github.com/justTOBBI)
+-   [colderinit](https://github.com/colderinit)
 
 &nbsp;
 

--- a/assets/manifest.template.json
+++ b/assets/manifest.template.json
@@ -1,0 +1,22 @@
+{
+	"manifestVersion": 1,
+	"id": "catppuccin-<theme name>",
+	"name": "Catppuccin <theme name> Theme",
+	"author": "<authors>",
+	"repoUrl": "https://github.com/catppuccin/remnote",
+	"enableOnMobile": false,
+	"version": {
+		"major": 0,
+		"minor": 1,
+		"patch": 0
+	},
+	"theme": ["dark"],
+	"description": "Catppuccin <theme name> Theme for Remnote.",
+	"requestNative": false,
+	"requiredScopes": [
+		{
+			"type": "All",
+			"level": "Read"
+		}
+	]
+}

--- a/frappé/manifest.json
+++ b/frappé/manifest.json
@@ -2,7 +2,7 @@
 	"manifestVersion": 1,
 	"id": "catppuccin-frappe",
 	"name": "Catppuccin Frappé Theme",
-	"author": "<authors>",
+	"author": "justTOBBI, colderinit",
 	"repoUrl": "https://github.com/catppuccin/remnote",
 	"enableOnMobile": false,
 	"version": {
@@ -11,7 +11,7 @@
 		"patch": 0
 	},
 	"theme": ["dark"],
-	"description": "Catppuccin Frappé Theme for Remnote.",
+	"description": "Catppuccin Frappé Theme for Remnote. Requires dark mode.",
 	"requestNative": false,
 	"requiredScopes": [
 		{

--- a/frappé/manifest.json
+++ b/frappé/manifest.json
@@ -1,0 +1,22 @@
+{
+	"manifestVersion": 1,
+	"id": "catppuccin-frappe",
+	"name": "Catppuccin Frappé Theme",
+	"author": "<authors>",
+	"repoUrl": "https://github.com/catppuccin/remnote",
+	"enableOnMobile": false,
+	"version": {
+		"major": 0,
+		"minor": 1,
+		"patch": 0
+	},
+	"theme": ["dark"],
+	"description": "Catppuccin Frappé Theme for Remnote.",
+	"requestNative": false,
+	"requiredScopes": [
+		{
+			"type": "All",
+			"level": "Read"
+		}
+	]
+}

--- a/frappé/theme.css
+++ b/frappé/theme.css
@@ -128,7 +128,7 @@
 
 /* rem */
 .rn-rem-reference {
-	color: var(--surface1);
+	color: var(--blue);
 }
 .rn-button {
 	color: var(--surface1);
@@ -207,4 +207,7 @@
 .dark .highlight-color--green {
 	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
 	--tw-bg-opacity: 0.5;
+}
+#search-results__no-results {
+	color: var(--text);
 }

--- a/frappé/theme.css
+++ b/frappé/theme.css
@@ -18,11 +18,193 @@
 	--subtext0: #a5adce;
 	--overlay2: #949cbb;
 	--overlay1: #838ba7;
-	--overlay: #737994;
+	--overlay0: #737994;
 	--surface2: #626880;
 	--surface1: #51576d;
-	--surfaceo: #414559;
+	--surface0: #414559;
 	--base: #303446;
 	--mantle: #292c3c;
 	--crust: #232634;
+	/* convert these hexadecimal values into rgb values */
+	--rosewater-rgb: 242, 213, 207;
+	--flamingo-rgb: 238, 190, 190;
+	--pink-rgb: 244, 184, 228;
+	--mauve-rgb: 202, 158, 230;
+	--red-rgb: 231, 130, 132;
+	--maroon-rgb: 234, 153, 156;
+	--peach-rgb: 239, 159, 118;
+	--yellow-rgb: 229, 200, 144;
+	--green-rgb: 166, 209, 137;
+	--teal-rgb: 129, 200, 190;
+	--sky-rgb: 153, 209, 219;
+	--sapphire-rgb: 133, 193, 220;
+	--blue-rgb: 140, 170, 238;
+	--lavender-rgb: 186, 187, 241;
+	--text-rgb: 198, 208, 245;
+	--subtext1-rgb: 181, 191, 226;
+	--subtext0-rgb: 165, 173, 206;
+	--overlay2-rgb: 148, 156, 187;
+	--overlay1-rgb: 131, 139, 167;
+	--overlay0-rgb: 115, 121, 148;
+	--surface2-rgb: 98, 104, 128;
+	--surface1-rgb: 81, 87, 109;
+	--surface0-rgb: 65, 69, 89;
+	--base-rgb: 48, 52, 70;
+	--mantle-rgb: 41, 44, 60;
+	--crust-rgb: 35, 38, 52;
+}
+
+.dark .bg-gray-5 {
+	background-color: var(--mantle);
+}
+#document-sidebar {
+	background-color: var(--mantle);
+}
+.rn-clr-background-primary {
+	background-color: var(--base);
+}
+.rn-clr-background-secondary {
+	background-color: var(--mantle);
+}
+.rn-clr-background-tertiary {
+	background-color: var(--crust);
+}
+.rn-clr-background {
+	background-color: var(--base);
+}
+.rn-clr-background-accent {
+	background-color: var(--surface2);
+}
+.rn-clr-background-accent--hovered {
+	background: var(--overlay0);
+	background-color: var(--overlay0);
+}
+.rn-clr-background-light-accent {
+	background-color: var(--surface2);
+}
+.rn-pane {
+	background-color: var(--base);
+}
+.rn-pane__body {
+	background-color: var(--base);
+}
+.rn-pane__top-bar {
+	background-color: var(--base);
+}
+
+.rn-editor__rem__body__text {
+	color: var(--text);
+}
+.rn-editor__rem__body {
+	background-color: var(--base);
+}
+.rn-clr-content-primary {
+	color: var(--text);
+}
+.rn-clr-content-accent {
+	color: var(--subtext1);
+}
+.rn-clr-content-tertiary {
+	color: var(--subtext0);
+}
+
+.top-bar-container {
+	background-color: var(--base);
+}
+
+/* clozes */
+
+.dark .cloze {
+	background-color: var(--surface0);
+}
+.cloze {
+	border-bottom-color: var(--blue);
+}
+.dark .rich-text-editor__change-cloze-button {
+	background-color: var(--blue), var(--tw-bg-opacity);
+
+	--tw-bg-opacity: 1;
+}
+
+/* rem */
+.rn-rem-reference {
+	color: var(--surface1);
+}
+.rn-button {
+	color: var(--surface1);
+}
+.rn-button--hovered {
+	color: var(--surface2);
+}
+.rn-editor__rem__body--red {
+	color: var(--red);
+}
+.rn-editor__rem__body--orange {
+	color: var(--peach);
+}
+.rn-editor__rem__body--yellow {
+	color: var(--yellow);
+}
+.rn-editor__rem__body--blue {
+	color: var(--sapphire);
+}
+.rn-editor__rem__body--purple {
+	color: var(--lavender);
+}
+.rn-editor__rem__body--green {
+	color: var(--green);
+}
+
+/* overlays (omnibar, slash menu) */
+
+.rn-omnibar {
+	background-color: var(--overlay1);
+}
+.rn-menu {
+	background-color: var(--overlay2);
+}
+.rn-dialog-overlay {
+	background-color: var(--overlay0);
+}
+/* search result and elevations */
+
+.rn-clr-background-elevation-10 {
+	background: var(--surface0);
+}
+
+/* color reassignments */
+/* this is literally just the favorite star :) */
+.dark .text-yellow-60 {
+	color: var(--yellow);
+}
+
+/* highlight reassignments */
+.dark .highlight-color--red {
+	background-color: rgba(var(--red-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--orange {
+	background-color: rgba(var(--peach-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--yellow {
+	background-color: rgba(var(--yellow-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--blue {
+	background-color: rgba(var(--sapphire-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--purple {
+	background-color: rgba(var(--lavender-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--green {
+	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
 }

--- a/frappé/theme.css
+++ b/frappé/theme.css
@@ -1,0 +1,28 @@
+:root {
+	--rosewater: #f2d5cf;
+	--flamingo: #eebebe;
+	--pink: #f4b8e4;
+	--mauve: #ca9ee6;
+	--red: #e78284;
+	--maroon: #ea999c;
+	--peach: #ef9f76;
+	--yellow: #e5c890;
+	--green: #a6d189;
+	--teal: #81c8be;
+	--sky: #99d1db;
+	--sapphire: #85c1dc;
+	--blue: #8caaee;
+	--lavender: #babbf1;
+	--text: #c6d0f5;
+	--subtext1: #b5bfe2;
+	--subtext0: #a5adce;
+	--overlay2: #949cbb;
+	--overlay1: #838ba7;
+	--overlay: #737994;
+	--surface2: #626880;
+	--surface1: #51576d;
+	--surfaceo: #414559;
+	--base: #303446;
+	--mantle: #292c3c;
+	--crust: #232634;
+}

--- a/latte/manifest.json
+++ b/latte/manifest.json
@@ -1,0 +1,22 @@
+{
+	"manifestVersion": 1,
+	"id": "catppuccin-latte",
+	"name": "Catppuccin Latte Theme",
+	"author": "<authors>",
+	"repoUrl": "https://github.com/catppuccin/remnote",
+	"enableOnMobile": false,
+	"version": {
+		"major": 0,
+		"minor": 1,
+		"patch": 0
+	},
+	"theme": ["dark"],
+	"description": "Catppuccin Latte Theme for Remnote.",
+	"requestNative": false,
+	"requiredScopes": [
+		{
+			"type": "All",
+			"level": "Read"
+		}
+	]
+}

--- a/latte/manifest.json
+++ b/latte/manifest.json
@@ -2,7 +2,7 @@
 	"manifestVersion": 1,
 	"id": "catppuccin-latte",
 	"name": "Catppuccin Latte Theme",
-	"author": "<authors>",
+	"author": "justTOBBI, colderinit",
 	"repoUrl": "https://github.com/catppuccin/remnote",
 	"enableOnMobile": false,
 	"version": {
@@ -10,8 +10,8 @@
 		"minor": 1,
 		"patch": 0
 	},
-	"theme": ["dark"],
-	"description": "Catppuccin Latte Theme for Remnote.",
+	"theme": ["light"],
+	"description": "Catppuccin Latte Theme for Remnote. Requires light mode.",
 	"requestNative": false,
 	"requiredScopes": [
 		{

--- a/latte/theme.css
+++ b/latte/theme.css
@@ -1,0 +1,28 @@
+:root {
+	--rosewater: #dc8a78;
+	--flamingo: #dd7878;
+	--pink: #ea76cb;
+	--mauve: #8839ef;
+	--red: #d20f39;
+	--maroon: #e64553;
+	--peach: #fe640b;
+	--yellow: #df8e1d;
+	--green: #40a02b;
+	--teal: #179299;
+	--sky: #04a5e5;
+	--sapphire: #209fb5;
+	--blue: #1e66f5;
+	--lavender: #7287fd;
+	--text: #4c4f69;
+	--subtext1: #5c5f77;
+	--subtext0: #6c6f85;
+	--overlay2: #7c7f93;
+	--overlay1: #8c8fa1;
+	--overlayo: #9ca0b0;
+	--surface2: #acb0be;
+	--surface1: #bcc0cc;
+	--surface0: #ccd0da;
+	--base: #eff1f5;
+	--mantle: #e6e9ef;
+	--crust: #dce0e8;
+}

--- a/latte/theme.css
+++ b/latte/theme.css
@@ -25,4 +25,187 @@
 	--base: #eff1f5;
 	--mantle: #e6e9ef;
 	--crust: #dce0e8;
+	/* convert the hexadecimal values above into rgb values */
+	--rosewater-rgb: 220, 138, 120;
+	--flamingo-rgb: 221, 120, 120;
+	--pink-rgb: 234, 118, 203;
+	--mauve-rgb: 136, 57, 239;
+	--red-rgb: 210, 15, 57;
+	--maroon-rgb: 230, 69, 83;
+	--peach-rgb: 254, 100, 11;
+	--yellow-rgb: 223, 142, 29;
+	--green-rgb: 64, 160, 43;
+	--teal-rgb: 23, 146, 153;
+	--sky-rgb: 4, 165, 229;
+	--sapphire-rgb: 32, 159, 181;
+	--blue-rgb: 30, 102, 245;
+	--lavender-rgb: 114, 135, 253;
+
+	--text-rgb: 76, 79, 105;
+	--subtext1-rgb: 92, 95, 119;
+	--subtext0-rgb: 108, 111, 133;
+	--overlay2-rgb: 124, 127, 147;
+	--overlay1-rgb: 140, 143, 161;
+	--overlay0-rgb: 156, 160, 176;
+	--surface2-rgb: 172, 176, 190;
+	--surface1-rgb: 188, 192, 204;
+	--surface0-rgb: 204, 208, 218;
+	--base-rgb: 239, 241, 245;
+	--mantle-rgb: 230, 233, 239;
+	--crust-rgb: 220, 224, 232;
+}
+
+.light .bg-gray-5 {
+	background-color: var(--mantle);
+}
+#document-sidebar {
+	background-color: var(--mantle);
+}
+.rn-clr-background-primary {
+	background-color: var(--base);
+}
+.rn-clr-background-secondary {
+	background-color: var(--mantle);
+}
+.rn-clr-background-tertiary {
+	background-color: var(--crust);
+}
+.rn-clr-background {
+	background-color: var(--base);
+}
+.rn-clr-background-accent {
+	background-color: var(--surface2);
+}
+.rn-clr-background-accent--hovered {
+	background: var(--overlay0);
+	background-color: var(--overlay0);
+}
+.rn-clr-background-light-accent {
+	background-color: var(--surface2);
+}
+.rn-pane {
+	background-color: var(--base);
+}
+.rn-pane__body {
+	background-color: var(--base);
+}
+.rn-pane__top-bar {
+	background-color: var(--base);
+}
+
+.rn-editor__rem__body__text {
+	color: var(--text);
+}
+.rn-editor__rem__body {
+	background-color: var(--base);
+}
+.rn-clr-content-primary {
+	color: var(--text);
+}
+.rn-clr-content-accent {
+	color: var(--subtext1);
+}
+.rn-clr-content-tertiary {
+	color: var(--subtext0);
+}
+
+.top-bar-container {
+	background-color: var(--base);
+}
+
+/* clozes */
+
+.light .cloze {
+	background-color: var(--surface0);
+}
+.cloze {
+	border-bottom-color: var(--blue);
+}
+.light .rich-text-editor__change-cloze-button {
+	background-color: var(--blue), var(--tw-bg-opacity);
+
+	--tw-bg-opacity: 1;
+}
+
+/* rem */
+.rn-rem-reference {
+	color: var(--surface1);
+}
+.rn-button {
+	color: var(--surface1);
+}
+.rn-button--hovered {
+	color: var(--surface2);
+}
+.rn-editor__rem__body--red {
+	color: var(--red);
+}
+.rn-editor__rem__body--orange {
+	color: var(--peach);
+}
+.rn-editor__rem__body--yellow {
+	color: var(--yellow);
+}
+.rn-editor__rem__body--blue {
+	color: var(--sapphire);
+}
+.rn-editor__rem__body--purple {
+	color: var(--lavender);
+}
+.rn-editor__rem__body--green {
+	color: var(--green);
+}
+
+/* overlays (omnibar, slash menu) */
+
+.rn-omnibar {
+	background-color: var(--overlay1);
+}
+.rn-menu {
+	background-color: var(--overlay2);
+}
+.rn-dialog-overlay {
+	background-color: var(--overlay0);
+}
+/* search result and elevations */
+
+.rn-clr-background-elevation-10 {
+	background: var(--surface0);
+}
+
+/* color reassignments */
+/* this is literally just the favorite star :) */
+.light .text-yellow-60 {
+	color: var(--yellow);
+}
+
+/* highlight reassignments */
+.light .highlight-color--red {
+	background-color: rgba(var(--red-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.light .highlight-color--orange {
+	background-color: rgba(var(--peach-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.light .highlight-color--yellow {
+	background-color: rgba(var(--yellow-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.light .highlight-color--blue {
+	background-color: rgba(var(--sapphire-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.light .highlight-color--purple {
+	background-color: rgba(var(--lavender-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.light .highlight-color--green {
+	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
 }

--- a/latte/theme.css
+++ b/latte/theme.css
@@ -129,7 +129,7 @@
 
 /* rem */
 .rn-rem-reference {
-	color: var(--surface1);
+	color: var(--blue);
 }
 .rn-button {
 	color: var(--surface1);
@@ -208,4 +208,7 @@
 .light .highlight-color--green {
 	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
 	--tw-bg-opacity: 0.5;
+}
+#search-results__no-results {
+	color: var(--text);
 }

--- a/macchiato/manifest.json
+++ b/macchiato/manifest.json
@@ -1,0 +1,22 @@
+{
+	"manifestVersion": 1,
+	"id": "catppuccin-macchiato",
+	"name": "Catppuccin Macchiato Theme",
+	"author": "justTOBBI, colderinit",
+	"repoUrl": "https://github.com/catppuccin/remnote",
+	"enableOnMobile": false,
+	"version": {
+		"major": 0,
+		"minor": 1,
+		"patch": 0
+	},
+	"theme": ["dark"],
+	"description": "Catppuccin Macchiato Theme for Remnote.",
+	"requestNative": false,
+	"requiredScopes": [
+		{
+			"type": "All",
+			"level": "Read"
+		}
+	]
+}

--- a/macchiato/manifest.json
+++ b/macchiato/manifest.json
@@ -11,7 +11,7 @@
 		"patch": 0
 	},
 	"theme": ["dark"],
-	"description": "Catppuccin Macchiato Theme for Remnote.",
+	"description": "Catppuccin Macchiato Theme for Remnote. Requires dark mode.",
 	"requestNative": false,
 	"requiredScopes": [
 		{

--- a/macchiato/theme.css
+++ b/macchiato/theme.css
@@ -144,7 +144,7 @@ TODO:
 
 /* rem */
 .rn-rem-reference {
-	color: var(--surface1);
+	color: var(--blue);
 }
 .rn-button {
 	color: var(--surface1);
@@ -223,4 +223,7 @@ TODO:
 .dark .highlight-color--green {
 	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
 	--tw-bg-opacity: 0.5;
+}
+#search-results__no-results {
+	color: var(--text);
 }

--- a/macchiato/theme.css
+++ b/macchiato/theme.css
@@ -1,3 +1,17 @@
+/* 
+@name           Remnote Catppuccin Mocha
+@namespace      github.com/catppuccin/remnote
+@version        0.1
+@description    Soothing pastel theme for Remnote
+@author         justTOBBI, colderinit
+
+Originally cloned from https://github.com/ethomasv/RemNoteTheme
+
+TODO: 
+- [ ] Fix Hover States
+- [ ] Fix Highlights
+*/
+
 :root {
 	--rosewater: #f4dbd6;
 	--flamingo: #f0c6c6;
@@ -18,11 +32,195 @@
 	--subtext0: #a5adcb;
 	--overlay2: #939ab7;
 	--overlay1: #8087a2;
-	--overlayo: #6e738d;
+	--overlay0: #6e738d;
 	--surface2: #566078;
 	--surface1: #494d64;
 	--surface0: #363a4f;
 	--base: #24273a;
 	--mantle: #1e2030;
 	--crust: #181926;
+	/* hexadecimal values from above in rgb form 
+	(These should probably be checked, 
+	as github copilot generated them)*/
+	--rosewater-rgb: 244, 219, 214;
+	--flamingo-rgb: 240, 198, 198;
+	--pink-rgb: 245, 189, 230;
+	--mauve-rgb: 198, 160, 246;
+	--red-rgb: 237, 135, 150;
+	--maroon-rgb: 238, 153, 160;
+	--peach-rgb: 245, 169, 127;
+	--yellow-rgb: 238, 212, 159;
+	--green-rgb: 166, 218, 149;
+	--teal-rgb: 139, 213, 202;
+	--sky-rgb: 145, 215, 227;
+	--sapphire-rgb: 125, 196, 228;
+	--blue-rgb: 138, 173, 244;
+	--lavender-rgb: 183, 189, 248;
+	--text-rgb: 202, 211, 245;
+	--subtext1-rgb: 184, 192, 224;
+	--subtext0-rgb: 165, 173, 203;
+	--overlay2-rgb: 147, 154, 183;
+	--overlay1-rgb: 128, 135, 162;
+	--overlay0-rgb: 110, 115, 141;
+	--surface2-rgb: 86, 96, 120;
+	--surface1-rgb: 73, 77, 100;
+	--surface0-rgb: 54, 58, 79;
+	--base-rgb: 36, 39, 58;
+	--mantle-rgb: 30, 32, 48;
+	--crust-rgb: 24, 25, 38;
+}
+
+.dark .bg-gray-5 {
+	background-color: var(--mantle);
+}
+#document-sidebar {
+	background-color: var(--mantle);
+}
+.rn-clr-background-primary {
+	background-color: var(--base);
+}
+.rn-clr-background-secondary {
+	background-color: var(--mantle);
+}
+.rn-clr-background-tertiary {
+	background-color: var(--crust);
+}
+.rn-clr-background {
+	background-color: var(--base);
+}
+.rn-clr-background-accent {
+	background-color: var(--surface2);
+}
+.rn-clr-background-accent--hovered {
+	background: var(--overlay0);
+	background-color: var(--overlay0);
+}
+.rn-clr-background-light-accent {
+	background-color: var(--surface2);
+}
+.rn-pane {
+	background-color: var(--base);
+}
+.rn-pane__body {
+	background-color: var(--base);
+}
+.rn-pane__top-bar {
+	background-color: var(--base);
+}
+
+.rn-editor__rem__body__text {
+	color: var(--text);
+}
+.rn-editor__rem__body {
+	background-color: var(--base);
+}
+.rn-clr-content-primary {
+	color: var(--text);
+}
+.rn-clr-content-accent {
+	color: var(--subtext1);
+}
+.rn-clr-content-tertiary {
+	color: var(--subtext0);
+}
+
+.top-bar-container {
+	background-color: var(--base);
+}
+
+/* clozes */
+
+.dark .cloze {
+	background-color: var(--surface0);
+}
+.cloze {
+	border-bottom-color: var(--blue);
+}
+.dark .rich-text-editor__change-cloze-button {
+	background-color: var(--blue), var(--tw-bg-opacity);
+
+	--tw-bg-opacity: 1;
+}
+
+/* rem */
+.rn-rem-reference {
+	color: var(--surface1);
+}
+.rn-button {
+	color: var(--surface1);
+}
+.rn-button--hovered {
+	color: var(--surface2);
+}
+.rn-editor__rem__body--red {
+	color: var(--red);
+}
+.rn-editor__rem__body--orange {
+	color: var(--peach);
+}
+.rn-editor__rem__body--yellow {
+	color: var(--yellow);
+}
+.rn-editor__rem__body--blue {
+	color: var(--sapphire);
+}
+.rn-editor__rem__body--purple {
+	color: var(--lavender);
+}
+.rn-editor__rem__body--green {
+	color: var(--green);
+}
+
+/* overlays (omnibar, slash menu) */
+
+.rn-omnibar {
+	background-color: var(--overlay1);
+}
+.rn-menu {
+	background-color: var(--overlay2);
+}
+.rn-dialog-overlay {
+	background-color: var(--overlay0);
+}
+/* search result and elevations */
+
+.rn-clr-background-elevation-10 {
+	background: var(--surface0);
+}
+
+/* color reassignments */
+/* this is literally just the favorite star :) */
+.dark .text-yellow-60 {
+	color: var(--yellow);
+}
+
+/* highlight reassignments */
+.dark .highlight-color--red {
+	background-color: rgba(var(--red-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--orange {
+	background-color: rgba(var(--peach-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--yellow {
+	background-color: rgba(var(--yellow-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--blue {
+	background-color: rgba(var(--sapphire-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--purple {
+	background-color: rgba(var(--lavender-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--green {
+	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
 }

--- a/macchiato/theme.css
+++ b/macchiato/theme.css
@@ -1,0 +1,28 @@
+:root {
+	--rosewater: #f4dbd6;
+	--flamingo: #f0c6c6;
+	--pink: #f5bde6;
+	--mauve: #c6a0f6;
+	--red: #ed8796;
+	--maroon: #ee99a0;
+	--peach: #f5a97f;
+	--yellow: #eed49f;
+	--green: #a6da95;
+	--teal: #8bd5ca;
+	--sky: #91d7e3;
+	--sapphire: #7dc4e4;
+	--blue: #8aadf4;
+	--lavender: #b7bdf8;
+	--text: #cad3f5;
+	--subtext1: #b8c0e0;
+	--subtext0: #a5adcb;
+	--overlay2: #939ab7;
+	--overlay1: #8087a2;
+	--overlayo: #6e738d;
+	--surface2: #566078;
+	--surface1: #494d64;
+	--surface0: #363a4f;
+	--base: #24273a;
+	--mantle: #1e2030;
+	--crust: #181926;
+}

--- a/mocha/manifest.json
+++ b/mocha/manifest.json
@@ -11,7 +11,7 @@
 		"patch": 0
 	},
 	"theme": ["dark"],
-	"description": "Catppuccin Mocha Theme for Remnote.",
+	"description": "Catppuccin Mocha Theme for Remnote. Requires dark mode.",
 	"requestNative": false,
 	"requiredScopes": [
 		{

--- a/mocha/manifest.json
+++ b/mocha/manifest.json
@@ -1,0 +1,22 @@
+{
+	"manifestVersion": 1,
+	"id": "catppuccin-mocha",
+	"name": "Catppuccin Mocha Theme",
+	"author": "justTOBBI, colderinit",
+	"repoUrl": "https://github.com/catppuccin/remnote",
+	"enableOnMobile": false,
+	"version": {
+		"major": 0,
+		"minor": 1,
+		"patch": 0
+	},
+	"theme": ["dark"],
+	"description": "Catppuccin Mocha Theme for Remnote.",
+	"requestNative": false,
+	"requiredScopes": [
+		{
+			"type": "All",
+			"level": "Read"
+		}
+	]
+}

--- a/mocha/theme.css
+++ b/mocha/theme.css
@@ -141,7 +141,7 @@ TODO:
 
 /* rem */
 .rn-rem-reference {
-	color: var(--surface1);
+	color: var(--blue);
 }
 .rn-button {
 	color: var(--surface1);
@@ -220,4 +220,7 @@ TODO:
 .dark .highlight-color--green {
 	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
 	--tw-bg-opacity: 0.5;
+}
+#search-results__no-results {
+	color: var(--text);
 }

--- a/mocha/theme.css
+++ b/mocha/theme.css
@@ -1,0 +1,37 @@
+/* I imagine header stuff here :) */
+
+:root {
+	--base: #1e1e2e;
+	--mantle: #181825;
+	--crust: #11111b;
+	--surface0: #313244;
+	--surface1: #45475a;
+	--surface2: #585b70;
+	--overlay0: #6c7086;
+	--overlay1: #7f849c;
+	--overlay2: #9399b2;
+	--subtext0: #a6adc8;
+	--subtext1: #bac2de;
+	--text: #cdd6f4;
+	--rosewater: #f5e0dc;
+	--flamingo: #f2cdcd;
+	--pink: #f5c2e7;
+	--mauve: #cba6f7;
+	--red: #f38ba8;
+	--maroon: #eba0ac;
+	--peach: #fab387;
+	--yellow: #f9e2af;
+	--green: #a6e3a1;
+	--teal: #94e2d5;
+	--sky: #89dceb;
+	--sapphire: #74c7ec;
+	--blue: #8964fa;
+	--lavender: #b4befe;
+}
+
+/* 
+    Main
+     */
+.rn-clr-background {
+	background-color: var(base);
+}

--- a/mocha/theme.css
+++ b/mocha/theme.css
@@ -38,17 +38,78 @@ TODO:
 	--sapphire: #74c7ec;
 	--blue: #8964fa;
 	--lavender: #b4befe;
+	/* convert hexadecimal to rgb values */
+	--rosewater-rgb: 245, 224, 220;
+	--flamingo-rgb: 242, 205, 205;
+	--pink-rgb: 245, 194, 231;
+	--mauve-rgb: 203, 166, 247;
+	--red-rgb: 243, 139, 168;
+	--maroon-rgb: 235, 160, 172;
+	--peach-rgb: 250, 179, 135;
+	--yellow-rgb: 249, 226, 175;
+	--green-rgb: 166, 227, 161;
+	--teal-rgb: 148, 226, 213;
+	--sky-rgb: 137, 220, 235;
+	--sapphire-rgb: 116, 199, 236;
+	--blue-rgb: 137, 100, 250;
+	--lavender-rgb: 180, 190, 254;
+	--text-rgb: 205, 214, 244;
+	--subtext1-rgb: 186, 194, 222;
+	--subtext0-rgb: 166, 173, 200;
+	--overlay2-rgb: 147, 153, 178;
+	--overlay1-rgb: 127, 132, 156;
+	--overlay0-rgb: 108, 112, 134;
+	--surface2-rgb: 88, 91, 112;
+	--surface1-rgb: 69, 71, 90;
+	--surface0-rgb: 49, 50, 68;
+	--crust-rgb: 17, 17, 27;
+	--mantle-rgb: 24, 24, 37;
+	--base-rgb: 30, 30, 46;
 }
 
-/* 
-    Main
-     */
-
+.dark .bg-gray-5 {
+	background-color: var(--mantle);
+}
+#document-sidebar {
+	background-color: var(--mantle);
+}
+.rn-clr-background-primary {
+	background-color: var(--base);
+}
+.rn-clr-background-secondary {
+	background-color: var(--mantle);
+}
+.rn-clr-background-tertiary {
+	background-color: var(--crust);
+}
+.rn-clr-background {
+	background-color: var(--base);
+}
+.rn-clr-background-accent {
+	background-color: var(--surface2);
+}
+.rn-clr-background-accent--hovered {
+	background: var(--overlay0);
+	background-color: var(--overlay0);
+}
+.rn-clr-background-light-accent {
+	background-color: var(--surface2);
+}
+.rn-pane {
+	background-color: var(--base);
+}
+.rn-pane__body {
+	background-color: var(--base);
+}
 .rn-pane__top-bar {
 	background-color: var(--base);
 }
+
 .rn-editor__rem__body__text {
 	color: var(--text);
+}
+.rn-editor__rem__body {
+	background-color: var(--base);
 }
 .rn-clr-content-primary {
 	color: var(--text);
@@ -59,13 +120,33 @@ TODO:
 .rn-clr-content-tertiary {
 	color: var(--subtext0);
 }
-.cloze {
+
+.top-bar-container {
+	background-color: var(--base);
+}
+
+/* clozes */
+
+.dark .cloze {
 	background-color: var(--surface0);
 }
+.cloze {
+	border-bottom-color: var(--blue);
+}
+.dark .rich-text-editor__change-cloze-button {
+	background-color: var(--blue), var(--tw-bg-opacity);
+
+	--tw-bg-opacity: 1;
+}
+
+/* rem */
 .rn-rem-reference {
 	color: var(--surface1);
 }
 .rn-button {
+	color: var(--surface1);
+}
+.rn-button--hovered {
 	color: var(--surface2);
 }
 .rn-editor__rem__body--red {
@@ -86,22 +167,57 @@ TODO:
 .rn-editor__rem__body--green {
 	color: var(--green);
 }
-#document-sidebar {
-	background-color: var(--base);
+
+/* overlays (omnibar, slash menu) */
+
+.rn-omnibar {
+	background-color: var(--overlay1);
 }
-.rn-clr-background-primary {
-	background-color: var(--base);
+.rn-menu {
+	background-color: var(--overlay2);
 }
-.rn-clr-background-secondary {
-	background-color: var(--mantle);
+.rn-dialog-overlay {
+	background-color: var(--overlay0);
+}
+/* search result and elevations */
+
+.rn-clr-background-elevation-10 {
+	background: var(--surface0);
 }
 
-.rn-clr-background {
-	background-color: var(--base);
+/* color reassignments */
+/* this is literally just the favorite star :) */
+.dark .text-yellow-60 {
+	color: var(--yellow);
 }
-.rn-clr-background-accent {
-	background-color: var(--surface2);
+
+/* highlight reassignments */
+.dark .highlight-color--red {
+	background-color: rgba(var(--red-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
 }
-.rn-pane__body {
-	background-color: var(--base);
+
+.dark .highlight-color--orange {
+	background-color: rgba(var(--peach-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--yellow {
+	background-color: rgba(var(--yellow-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--blue {
+	background-color: rgba(var(--sapphire-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--purple {
+	background-color: rgba(var(--lavender-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
+}
+
+.dark .highlight-color--green {
+	background-color: rgba(var(--green-rgb), var(--tw-bg-opacity));
+	--tw-bg-opacity: 0.5;
 }

--- a/mocha/theme.css
+++ b/mocha/theme.css
@@ -1,4 +1,15 @@
-/* I imagine header stuff here :) */
+/* 
+@name           Remnote Catppuccin Mocha
+@namespace      github.com/catppuccin/remnote
+@version        0.1
+@description    Soothing pastel theme for Remnote
+@author         justTOBBI, colderinit
+
+Originally cloned from https://github.com/ethomasv/RemNoteTheme
+
+TODO: 
+- [ ] Add Hover states?
+*/
 
 :root {
 	--base: #1e1e2e;
@@ -32,6 +43,65 @@
 /* 
     Main
      */
+
+.rn-pane__top-bar {
+	background-color: var(--base);
+}
+.rn-editor__rem__body__text {
+	color: var(--text);
+}
+.rn-clr-content-primary {
+	color: var(--text);
+}
+.rn-clr-content-accent {
+	color: var(--subtext1);
+}
+.rn-clr-content-tertiary {
+	color: var(--subtext0);
+}
+.cloze {
+	background-color: var(--surface0);
+}
+.rn-rem-reference {
+	color: var(--surface1);
+}
+.rn-button {
+	color: var(--surface2);
+}
+.rn-editor__rem__body--red {
+	color: var(--red);
+}
+.rn-editor__rem__body--orange {
+	color: var(--peach);
+}
+.rn-editor__rem__body--yellow {
+	color: var(--yellow);
+}
+.rn-editor__rem__body--blue {
+	color: var(--sapphire);
+}
+.rn-editor__rem__body--purple {
+	color: var(--lavender);
+}
+.rn-editor__rem__body--green {
+	color: var(--green);
+}
+#document-sidebar {
+	background-color: var(--base);
+}
+.rn-clr-background-primary {
+	background-color: var(--base);
+}
+.rn-clr-background-secondary {
+	background-color: var(--mantle);
+}
+
 .rn-clr-background {
-	background-color: var(base);
+	background-color: var(--base);
+}
+.rn-clr-background-accent {
+	background-color: var(--surface2);
+}
+.rn-pane__body {
+	background-color: var(--base);
 }


### PR DESCRIPTION
# Implementation of Catppuccin Themes: Mocha, Frappè, Latte, and Macchiato
Hi there! 👋 
I ported the four themes of Catppuccin over to remnote. I thought it a good idea to start the review process! 

I also reworked the structure of the repo to be compatible with uploading to the **Beta Themes Manager** in remote. 

<details><summary>Macchiato</summary>

![SCR-20221015-rlh](https://user-images.githubusercontent.com/66754842/196013187-48229089-661c-4d93-91ea-27436c844245.png)</details>
<details><summary>Frappé</summary>

![SCR-20221015-rk8](https://user-images.githubusercontent.com/66754842/196013190-fd417ef5-5d7b-470c-8ac9-469970ba48de.png)</details>
<details><summary>Latte</summary>

![SCR-20221015-rkw](https://user-images.githubusercontent.com/66754842/196013188-1d96fe75-5799-473c-bd32-d4f9f6a01529.png)</details>
<details><summary>Mocha</summary>

![SCR-20221015-rjn](https://user-images.githubusercontent.com/66754842/196013192-da5d9635-28d2-4f6f-94ab-f1399d727bc8.png)</details>
Cheers!
@justTOBBI 
@colderinit
Note:
_I was told to compare with the main branch, but `contributing.md` states otherwise. Please let me know if I should correct this!_